### PR TITLE
Added sudo to packages

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -12,7 +12,7 @@ FROM ubuntu:latest
 RUN apt update && apt upgrade -y
 RUN apt install -y isync
 RUN apt install -y openssl
-RUN apt install -y ca-certificates nano
+RUN apt install -y ca-certificates nano sudo
 
 
 COPY .mbsyncrc /etc/.mbsyncrc


### PR DESCRIPTION
run.sh uses sudo to run mbsync, which throws a sudo: command not found error when the container runs. This PR adds sudo to the list of packages installed. Tested satis on my instance