### PR TITLE
Add IMAP timeout

### DIFF
--- a/.mbsyncrc
+++ b/.mbsyncrc
@@ -3,6 +3,7 @@ IMAPAccount {mailbox_name}
 Host {host_name}
 Port {port}
 User {remote_username}
+Timeout {timeout}
 # For simplicity, this is how to read the password from another file.
 # For better security you should use GPG https://gnupg.org/
 Pass {remote_password}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.1" 
+version: "3.1"
 services:
   mbsync:
     image: thehelpfulidiot/mbsync:latest
@@ -14,3 +14,4 @@ services:
       - sslversions=TLSv1.2
       - mailbox_name=fastmail
       - pipeline_depth=1024 #default=1024 but may need to be changed for some mail providers (https://manpages.debian.org/unstable/isync/mbsync.1.en.html#PipelineDepth)
+      - timeout=20

--- a/dockerfile
+++ b/dockerfile
@@ -10,6 +10,7 @@ FROM ubuntu:latest
 #yes, no, or required
 #ENV server_address="imap.example.com"
 ENV pipeline_depth="1024"
+ENV timeout="20"
 
 RUN apt update && apt upgrade -y
 RUN apt install -y isync

--- a/run.sh
+++ b/run.sh
@@ -10,5 +10,5 @@ sed -i "s/{remote_username}/${remote_username}/g" /etc/.mbsyncrc
 sed -i "s/{remote_password}/${remote_password}/g" /etc/.mbsyncrc
 sed -i "s/{ssltype}/${ssltype}/g" /etc/.mbsyncrc
 sed -i "s/{sslversions}/${sslversions}/g" /etc/.mbsyncrc
-sed -i "s/{mailbox_name}/${mailbox_name}/g" /etc/.mbsyncrc
+sed -i "s/{timeout}/${timeout}/g" /etc/.mbsyncrc
 sudo -u mbsync mbsync -Va -c /etc/.mbsyncrc


### PR DESCRIPTION
I have some email folders with large amounts of emails that caused mbsync to timeout. I have added the ability to change the timeout to your container (default is 20s)